### PR TITLE
Principle Component Analysis Workload

### DIFF
--- a/dpbench/benchmarks/kmeans/kmeans_sycl_native_ext/kmeans_sycl/_kmeans_kernel.hpp
+++ b/dpbench/benchmarks/kmeans/kmeans_sycl_native_ext/kmeans_sycl/_kmeans_kernel.hpp
@@ -48,7 +48,8 @@ void kmeans_impl(sycl::queue q,
                         }
                         FpTy total_distance = cl::sycl::sqrt(sq_sum);
                         if (minor_distance > total_distance ||
-                            minor_distance == -1.0) {
+                            minor_distance == -1.0)
+                        {
                             minor_distance = total_distance;
                             arrayPclusters[i0] = i1;
                         }

--- a/dpbench/benchmarks/pca/__init__.py
+++ b/dpbench/benchmarks/pca/__init__.py
@@ -3,27 +3,17 @@
 # SPDX-License-Identifier: Apache 2.0
 
 from .pca_initialize import initialize
-from .pca_numpy import (
-    pca as pca_numpy
-)
-from .pca_numba_n import (
-    pca as pca_numba_n
-)
-
-from .pca_numba_np import (
-    pca as pca_numba_np
-)
-
-from .pca_numba_dpex_n import (
-    pca as pca_numba_dpex_n
-)
+from .pca_numba_dpex_n import pca as pca_numba_dpex_n
+from .pca_numba_n import pca as pca_numba_n
+from .pca_numba_np import pca as pca_numba_np
+from .pca_numpy import pca as pca_numpy
 
 __all__ = [
     "initialize",
     "pca_numpy",
     "pca_numba_n",
     "pca_numba_np",
-    "pca_numba_dpex_n"
+    "pca_numba_dpex_n",
 ]
 
 """Principle Component Analysis

--- a/dpbench/benchmarks/pca/__init__.py
+++ b/dpbench/benchmarks/pca/__init__.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache 2.0
+
+from .pca_initialize import initialize
+from .pca_numpy import (
+    pca as pca_numpy
+)
+from .pca_numba_n import (
+    pca as pca_numba_n
+)
+
+from .pca_numba_np import (
+    pca as pca_numba_np
+)
+
+from .pca_numba_dpex_n import (
+    pca as pca_numba_dpex_n
+)
+
+__all__ = [
+    "initialize",
+    "pca_numpy",
+    "pca_numba_n",
+    "pca_numba_np",
+    "pca_numba_dpex_n"
+]
+
+"""Principle Component Analysis
+
+Input
+---------
+data : array
+       random regression problem
+
+Output
+-------
+data: array
+      transformation on the data using eigenvectors
+
+evalues: array
+         Eigen values
+
+evectors: array
+          Eigen vectors
+
+Method
+------
+PCA implementation using covariance approach.
+Step 1) Calculate covariance matrix
+Step 2) Compute eigen values and eigen vectors from the covariance matrix
+"""

--- a/dpbench/benchmarks/pca/pca_initialize.py
+++ b/dpbench/benchmarks/pca/pca_initialize.py
@@ -1,0 +1,8 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+def initialize(npoints, dims):
+    from sklearn.datasets import make_regression
+    return make_regression(n_samples=npoints, n_features=dims)

--- a/dpbench/benchmarks/pca/pca_initialize.py
+++ b/dpbench/benchmarks/pca/pca_initialize.py
@@ -5,4 +5,5 @@
 
 def initialize(npoints, dims):
     from sklearn.datasets import make_regression
+
     return make_regression(n_samples=npoints, n_features=dims)

--- a/dpbench/benchmarks/pca/pca_numba_dpex_n.py
+++ b/dpbench/benchmarks/pca/pca_numba_dpex_n.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import numba as nb
+
+
+nb.njit(parallel=True, fastmath=True)
+def pca(data, dims_rescaled_data=2):
+    # mean center the data
+    data -= data.mean(axis=0)
+
+    # calculate the covariance matrix
+    v = np.cov(data, rowvar=False)
+
+    # calculate eigenvectors & eigenvalues of the covariance matrix
+    evalues, evectors = np.linalg.eigh(v)
+
+    # sort eigenvalues and eigenvectors in decreasing order
+    idx = np.argsort(evalues)[::-1]
+    evectors = evectors[:,idx]
+    evalues = evalues[idx]
+
+    # select the first n eigenvectors (n is desired dimension
+    # of rescaled data array, or dims_rescaled_data)
+    evectors = evectors[:, :dims_rescaled_data]
+
+    # carry out the transformation on the data using eigenvectors
+    tdata = np.dot(evectors.T, data.T).T
+
+    # return the transformed data, eigenvalues, and eigenvectors
+    return tdata, evalues, evectors

--- a/dpbench/benchmarks/pca/pca_numba_dpex_n.py
+++ b/dpbench/benchmarks/pca/pca_numba_dpex_n.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 import numba as nb
-
+import numpy as np
 
 nb.njit(parallel=True, fastmath=True)
+
+
 def pca(data, dims_rescaled_data=2):
     # mean center the data
     data -= data.mean(axis=0)
@@ -19,7 +20,7 @@ def pca(data, dims_rescaled_data=2):
 
     # sort eigenvalues and eigenvectors in decreasing order
     idx = np.argsort(evalues)[::-1]
-    evectors = evectors[:,idx]
+    evectors = evectors[:, idx]
     evalues = evalues[idx]
 
     # select the first n eigenvectors (n is desired dimension

--- a/dpbench/benchmarks/pca/pca_numba_n.py
+++ b/dpbench/benchmarks/pca/pca_numba_n.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 import numba as nb
-
+import numpy as np
 
 nb.njit(parallel=False, fastmath=True)
+
+
 def pca(data, dims_rescaled_data=2):
     # mean center the data
     data -= data.mean(axis=0)
@@ -19,7 +20,7 @@ def pca(data, dims_rescaled_data=2):
 
     # sort eigenvalues and eigenvectors in decreasing order
     idx = np.argsort(evalues)[::-1]
-    evectors = evectors[:,idx]
+    evectors = evectors[:, idx]
     evalues = evalues[idx]
 
     # select the first n eigenvectors (n is desired dimension

--- a/dpbench/benchmarks/pca/pca_numba_n.py
+++ b/dpbench/benchmarks/pca/pca_numba_n.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import numba as nb
+
+
+nb.njit(parallel=False, fastmath=True)
+def pca(data, dims_rescaled_data=2):
+    # mean center the data
+    data -= data.mean(axis=0)
+
+    # calculate the covariance matrix
+    v = np.cov(data, rowvar=False)
+
+    # calculate eigenvectors & eigenvalues of the covariance matrix
+    evalues, evectors = np.linalg.eigh(v)
+
+    # sort eigenvalues and eigenvectors in decreasing order
+    idx = np.argsort(evalues)[::-1]
+    evectors = evectors[:,idx]
+    evalues = evalues[idx]
+
+    # select the first n eigenvectors (n is desired dimension
+    # of rescaled data array, or dims_rescaled_data)
+    evectors = evectors[:, :dims_rescaled_data]
+
+    # carry out the transformation on the data using eigenvectors
+    tdata = np.dot(evectors.T, data.T).T
+
+    # return the transformed data, eigenvalues, and eigenvectors
+    return tdata, evalues, evectors

--- a/dpbench/benchmarks/pca/pca_numba_np.py
+++ b/dpbench/benchmarks/pca/pca_numba_np.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import numba as nb
+
+
+nb.njit(parallel=True, fastmath=True)
+def pca(data, dims_rescaled_data=2):
+    # mean center the data
+    data -= data.mean(axis=0)
+
+    # calculate the covariance matrix
+    v = np.cov(data, rowvar=False)
+
+    # calculate eigenvectors & eigenvalues of the covariance matrix
+    evalues, evectors = np.linalg.eigh(v)
+
+    # sort eigenvalues and eigenvectors in decreasing order
+    idx = np.argsort(evalues)[::-1]
+    evectors = evectors[:,idx]
+    evalues = evalues[idx]
+
+    # select the first n eigenvectors (n is desired dimension
+    # of rescaled data array, or dims_rescaled_data)
+    evectors = evectors[:, :dims_rescaled_data]
+
+    # carry out the transformation on the data using eigenvectors
+    tdata = np.dot(evectors.T, data.T).T
+
+    # return the transformed data, eigenvalues, and eigenvectors
+    return tdata, evalues, evectors

--- a/dpbench/benchmarks/pca/pca_numba_np.py
+++ b/dpbench/benchmarks/pca/pca_numba_np.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 import numba as nb
-
+import numpy as np
 
 nb.njit(parallel=True, fastmath=True)
+
+
 def pca(data, dims_rescaled_data=2):
     # mean center the data
     data -= data.mean(axis=0)
@@ -19,7 +20,7 @@ def pca(data, dims_rescaled_data=2):
 
     # sort eigenvalues and eigenvectors in decreasing order
     idx = np.argsort(evalues)[::-1]
-    evectors = evectors[:,idx]
+    evectors = evectors[:, idx]
     evalues = evalues[idx]
 
     # select the first n eigenvectors (n is desired dimension

--- a/dpbench/benchmarks/pca/pca_numpy.py
+++ b/dpbench/benchmarks/pca/pca_numpy.py
@@ -1,0 +1,31 @@
+# Copyright 2022 Intel Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+
+def pca(data, dims_rescaled_data=2):
+    # mean center the data
+    data -= data.mean(axis=0)
+
+    # calculate the covariance matrix
+    v = np.cov(data, rowvar=False)
+
+    # calculate eigenvectors & eigenvalues of the covariance matrix
+    evalues, evectors = np.linalg.eigh(v)
+
+    # sort eigenvalues and eigenvectors in decreasing order
+    idx = np.argsort(evalues)[::-1]
+    evectors = evectors[:,idx]
+    evalues = evalues[idx]
+
+    # select the first n eigenvectors (n is desired dimension
+    # of rescaled data array, or dims_rescaled_data)
+    evectors = evectors[:, :dims_rescaled_data]
+
+    # carry out the transformation on the data using eigenvectors
+    tdata = np.dot(evectors.T, data.T).T
+
+    # return the transformed data, eigenvalues, and eigenvectors
+    return tdata, evalues, evectors

--- a/dpbench/benchmarks/pca/pca_numpy.py
+++ b/dpbench/benchmarks/pca/pca_numpy.py
@@ -17,7 +17,7 @@ def pca(data, dims_rescaled_data=2):
 
     # sort eigenvalues and eigenvectors in decreasing order
     idx = np.argsort(evalues)[::-1]
-    evectors = evectors[:,idx]
+    evectors = evectors[:, idx]
     evalues = evalues[idx]
 
     # select the first n eigenvectors (n is desired dimension

--- a/dpbench/configs/bench_info/pca.json
+++ b/dpbench/configs/bench_info/pca.json
@@ -1,0 +1,46 @@
+{
+    "benchmark": {
+        "name": "Principle Component Analysis",
+        "short_name": "PCA",
+        "relative_path": "pca",
+        "module_name": "pca",
+        "func_name": "pca",
+        "kind": "benchmark",
+        "domain": "data analysis",
+        "parameters": {
+            "S": {
+                "npoints": 1024,
+		"dims": 128
+            },
+            "M": {
+                "npoints": 16384,
+		"dims": 128
+            },
+            "L": {
+                "npoints": 524288,
+		"dims": 128
+            }
+        },
+        "init": {
+            "func_name": "initialize",
+            "input_args": [
+                "npoints",
+		"dims"
+            ],
+            "output_args": [
+		"data"
+            ]
+        },
+        "input_args": [
+            "data"
+        ],
+        "array_args": [
+            "data"
+        ],
+        "output_args": [
+            "data",
+	    "evalues",
+	    "evectors"
+        ]
+    }
+}


### PR DESCRIPTION
This PR adds implementations of PCA workload to dpbench. The initial implementations include numpy, numba without parallel decorator, numba with parallel decorator and numba-dpex.
- [x] Have you provided a meaningful PR description?
- [x] Have you added a test, reproducer or referred to an issue with a reproducer?
- [x] Have you tested your changes locally for CPU and GPU devices?
- [x] Have you made sure that new changes do not introduce compiler warnings?
- [x] If this PR is a work in progress, are you filing the PR as a draft?
